### PR TITLE
Reload and Consumable Ground Items

### DIFF
--- a/Assets/PlayerActions.inputactions
+++ b/Assets/PlayerActions.inputactions
@@ -40,6 +40,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Reload",
+                    "type": "Button",
+                    "id": "d1ae5310-2d49-4ac0-a679-e9b72632a182",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -370,6 +379,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Inventory",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2554c944-47ef-4682-a783-ce00939f588f",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Reload",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Resources/Prefabs/Ammo.prefab
+++ b/Assets/Resources/Prefabs/Ammo.prefab
@@ -1,0 +1,365 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &64022546415894319
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4285360912228076773}
+  - component: {fileID: 792052927516532362}
+  - component: {fileID: 159250130294719420}
+  - component: {fileID: -8478510280921730741}
+  m_Layer: 0
+  m_Name: Ammo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4285360912228076773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64022546415894319}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.76161575, y: 0.7299187, z: -0.059348952}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6169433990898865040}
+  - {fileID: 594221171246305721}
+  - {fileID: 1944739016907485718}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &792052927516532362
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64022546415894319}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!58 &159250130294719420
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64022546415894319}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.054220557, y: 0.29661977}
+  serializedVersion: 2
+  m_Radius: 0.6467153
+--- !u!114 &-8478510280921730741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 64022546415894319}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e456042ff56ad4048a51ef9c63c352a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5782976124767057368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 594221171246305721}
+  - component: {fileID: 2030335299822892442}
+  m_Layer: 0
+  m_Name: Triangle (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &594221171246305721
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5782976124767057368}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.027, y: 0.238, z: 0.059348952}
+  m_LocalScale: {x: 0.28552037, y: 0.6109, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4285360912228076773}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2030335299822892442
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5782976124767057368}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Color: {r: 0.9676323, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &6320488004692376071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6169433990898865040}
+  - component: {fileID: 8429550410628367797}
+  m_Layer: 0
+  m_Name: Triangle (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6169433990898865040
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6320488004692376071}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.286, y: 0.5, z: 0.059348952}
+  m_LocalScale: {x: 0.28552037, y: 0.6109, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4285360912228076773}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8429550410628367797
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6320488004692376071}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Color: {r: 0.9676323, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &6784815373721257051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1944739016907485718}
+  - component: {fileID: 1270937956795103269}
+  m_Layer: 0
+  m_Name: Triangle (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1944739016907485718
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6784815373721257051}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.352, y: -0.024, z: 0.059348952}
+  m_LocalScale: {x: 0.28552037, y: 0.6109, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4285360912228076773}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1270937956795103269
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6784815373721257051}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Color: {r: 0.9676323, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Resources/Prefabs/Ammo.prefab.meta
+++ b/Assets/Resources/Prefabs/Ammo.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 421dc4af855ac584dbe884ffa25fe36a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1337,6 +1337,150 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2022782275
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2022782279}
+  - component: {fileID: 2022782278}
+  - component: {fileID: 2022782277}
+  - component: {fileID: 2022782276}
+  m_Layer: 0
+  m_Name: SpawnCharacter (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2022782276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2022782275}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e94f5bf92b7682046bdfe929b6be89bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  count: 20
+--- !u!61 &2022782277
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2022782275}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &2022782278
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2022782275}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.26400995, g: 0, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &2022782279
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2022782275}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.6, y: -4.01, z: 0}
+  m_LocalScale: {x: 1.2103215, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2141155188
 GameObject:
   m_ObjectHideFlags: 0
@@ -1392,6 +1536,7 @@ SceneRoots:
   - {fileID: 1758195444}
   - {fileID: 1900289039}
   - {fileID: 1521124626}
+  - {fileID: 2022782279}
   - {fileID: 830099482}
   - {fileID: 1410088003}
   - {fileID: 214935734}

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -35,7 +35,7 @@ public class Bullet : MonoBehaviour
         }
     }
     // Detect collision
-    private void OnTriggerEnter2D(Collider2D collision)
+    public void OnTriggerEnter2D(Collider2D collision)
     {
         Character c = collision.gameObject.GetComponent<Character>();
         // If null we hit a wall or a non-character, therefore destroy the bullet

--- a/Assets/Scripts/Characters/Character.cs
+++ b/Assets/Scripts/Characters/Character.cs
@@ -41,7 +41,7 @@ public interface IInventory
     int InventorySize { get; }
     int Hotkey { get; set; }
     void UseItem();
-    void PickUpItem(IItem item);
+    void PickUpItem(IHoldableItem item);
     void DropItem();
 }
 
@@ -58,7 +58,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     protected float _defense;
     protected int _hotkey;
     protected int _ammo;
-    protected IItem[] _inventory;
+    protected IHoldableItem[] _inventory;
 
     // Implementations of interface functions and variables
     public Component component { get { return this; } }
@@ -137,6 +137,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     // Every character will have the same attack logic, just with a different weapon
     public void UseItem()
     {
+        Debug.Log(this.Ammo);
         if (_inventory[_hotkey] != null)
         {
             _inventory[_hotkey].Use();
@@ -156,7 +157,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
             }
         }
     }
-    public void PickUpItem(IItem item)
+    public void PickUpItem(IHoldableItem item)
     {
         for(int i = 0; i < _inventory.Length; i++)
         {

--- a/Assets/Scripts/Characters/Character.cs
+++ b/Assets/Scripts/Characters/Character.cs
@@ -30,8 +30,6 @@ public interface ICharacter : IComponent
     void Heal(float hp);
     // Reload the charactere's ammo
     void StockAmmo(int ammo);
-    // Reload the charactere's ammo
-    void UseAmmo(int ammo);
     // Terminate the character gameobject
     void Terminate();
 
@@ -42,7 +40,7 @@ public interface IInventory
 {
     int InventorySize { get; }
     int Hotkey { get; set; }
-    void UseItem(int flag = 0);
+    void UseItem();
     void PickUpItem(IItem item);
     void DropItem();
 }
@@ -137,14 +135,27 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
         GetComponent<Rigidbody2D>().velocity = new Vector2(dx * MovementSpeed, dy * MovementSpeed);
     }
     // Every character will have the same attack logic, just with a different weapon
-    public void UseItem(int flag = 0)
+    public void UseItem()
     {
         if (_inventory[_hotkey] != null)
         {
-            _inventory[_hotkey].Use(this, flag);
+            _inventory[_hotkey].Use();
         }
     }
 
+    // Reload the current item if it supports reloading
+    public void Reload()
+    {
+        if (_inventory[_hotkey] != null)
+        {
+            ItemType type = _inventory[_hotkey].Type;
+            if(type == ItemType.FIREARM)
+            {
+                IFirearm firearm = (IFirearm) _inventory[_hotkey];
+                this._ammo = firearm.Reload(_ammo);
+            }
+        }
+    }
     public void PickUpItem(IItem item)
     {
         for(int i = 0; i < _inventory.Length; i++)
@@ -192,15 +203,6 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     public void StockAmmo(int ammo)
     {
         this._ammo += ammo;
-    }
-    // Use ammo
-    public void UseAmmo(int ammo)
-    {
-        this._ammo -= ammo;
-        if(this._ammo < 0)
-        {
-            this._ammo = 0;
-        }
     }
     // Terminate the current character GameObject
     public void Terminate()

--- a/Assets/Scripts/Characters/Character.cs
+++ b/Assets/Scripts/Characters/Character.cs
@@ -16,6 +16,8 @@ public interface ICharacter : IComponent
     float MaxHealth { get; }
     // Represents the defense of a character (lowers the damage they take)
     float Defense { get; }
+    // Characters need to hold ammo
+    int Ammo { get; }
     // Chracters need to implement their own move logic
     void Move(float dx, float dy);
     // Characters need to take damage
@@ -26,6 +28,10 @@ public interface ICharacter : IComponent
     void Upgrade(float hp, float defense, float movementSpeed);
     // Heal the character some amount
     void Heal(float hp);
+    // Reload the charactere's ammo
+    void StockAmmo(int ammo);
+    // Reload the charactere's ammo
+    void UseAmmo(int ammo);
     // Terminate the character gameobject
     void Terminate();
 
@@ -36,7 +42,7 @@ public interface IInventory
 {
     int InventorySize { get; }
     int Hotkey { get; set; }
-    void UseItem();
+    void UseItem(int flag = 0);
     void PickUpItem(IItem item);
     void DropItem();
 }
@@ -53,6 +59,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     protected float _health;
     protected float _defense;
     protected int _hotkey;
+    protected int _ammo;
     protected IItem[] _inventory;
 
     // Implementations of interface functions and variables
@@ -96,6 +103,11 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
             }
         }
     }
+    public int Ammo
+    {
+        get { return _ammo; }
+    }
+
     // Character needs to have its layer set (player enemy)
     public void SetLayer(int layer)
     {
@@ -125,11 +137,11 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
         GetComponent<Rigidbody2D>().velocity = new Vector2(dx * MovementSpeed, dy * MovementSpeed);
     }
     // Every character will have the same attack logic, just with a different weapon
-    public void UseItem()
+    public void UseItem(int flag = 0)
     {
         if (_inventory[_hotkey] != null)
         {
-            _inventory[_hotkey].Use();
+            _inventory[_hotkey].Use(this, flag);
         }
     }
 
@@ -139,6 +151,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
         {
             if (_inventory[i] == null)
             {
+                // IF ITS AMMO ADD IT TO OUR 
                 _inventory[i] = item;
                 return;
             }
@@ -174,6 +187,20 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     public void Heal(float hp)
     {
         this._health = Mathf.Clamp(this.Health + hp, 0, this.MaxHealth);
+    }
+    // Stock ammo
+    public void StockAmmo(int ammo)
+    {
+        this._ammo += ammo;
+    }
+    // Use ammo
+    public void UseAmmo(int ammo)
+    {
+        this._ammo -= ammo;
+        if(this._ammo < 0)
+        {
+            this._ammo = 0;
+        }
     }
     // Terminate the current character GameObject
     public void Terminate()

--- a/Assets/Scripts/Characters/Character.cs
+++ b/Assets/Scripts/Characters/Character.cs
@@ -137,7 +137,6 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     // Every character will have the same attack logic, just with a different weapon
     public void UseItem()
     {
-        Debug.Log(this.Ammo);
         if (_inventory[_hotkey] != null)
         {
             _inventory[_hotkey].Use();

--- a/Assets/Scripts/Characters/Ranger.cs
+++ b/Assets/Scripts/Characters/Ranger.cs
@@ -20,6 +20,6 @@ public class Ranger : Character
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
         this._ammo = 32;
-        this._inventory = new IItem[5];
+        this._inventory = new IHoldableItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Ranger.cs
+++ b/Assets/Scripts/Characters/Ranger.cs
@@ -19,6 +19,7 @@ public class Ranger : Character
         this._health = defaultHealth;
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
+        this._ammo = 32;
         this._inventory = new IItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Sniper.cs
+++ b/Assets/Scripts/Characters/Sniper.cs
@@ -20,6 +20,6 @@ public class Sniper : Character
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
         this._ammo = 32;
-        this._inventory = new IItem[5];
+        this._inventory = new IHoldableItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Sniper.cs
+++ b/Assets/Scripts/Characters/Sniper.cs
@@ -19,6 +19,7 @@ public class Sniper : Character
         this._health = defaultHealth;
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
+        this._ammo = 32;
         this._inventory = new IItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Soldier.cs
+++ b/Assets/Scripts/Characters/Soldier.cs
@@ -19,6 +19,7 @@ public class Soldier : Character
         this._health = defaultHealth;
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
+        this._ammo = 64;
         this._inventory = new IItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Soldier.cs
+++ b/Assets/Scripts/Characters/Soldier.cs
@@ -20,6 +20,6 @@ public class Soldier : Character
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
         this._ammo = 64;
-        this._inventory = new IItem[5];
+        this._inventory = new IHoldableItem[5];
     }
 }

--- a/Assets/Scripts/Items/Ammo.cs
+++ b/Assets/Scripts/Items/Ammo.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using static UnityEditor.Experimental.GraphView.GraphView;
+
+public class Ammo : DropItem
+{
+    private int _count;
+
+    public void Awake()
+    {
+        _count = 0;
+    }
+    public int Count { get { return _count; } set { _count = value; } }
+
+    public override void OnTriggerEnter2D(Collider2D collision)
+    {
+        Character c = collision.gameObject.GetComponent<Character>();
+        // Must be picked up by a character
+        if (c)
+        {
+            // Must be a player
+            if (c.gameObject.layer == Layers.PLAYER)
+            {
+                c.StockAmmo(_count);
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Items/Ammo.cs.meta
+++ b/Assets/Scripts/Items/Ammo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e456042ff56ad4048a51ef9c63c352a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items/Consumable.cs
+++ b/Assets/Scripts/Items/Consumable.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class DropItem : Item, IDropItem
+{
+    public override ItemType Type
+    {
+        get { return ItemType.DROP; }
+    }
+    public abstract void OnTriggerEnter2D(Collider2D collision);
+}

--- a/Assets/Scripts/Items/Consumable.cs.meta
+++ b/Assets/Scripts/Items/Consumable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 655328f4be4d02d45b484a547c6ab30a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items/Crossbow.cs
+++ b/Assets/Scripts/Items/Crossbow.cs
@@ -21,7 +21,7 @@ public class Crossbow : Firearm
         this.bulletSpawner = ScriptableObject.CreateInstance<BulletSpawner>();
         this.bulletSpawner.Initialize(this);
     }
-    public override void Use()
+    protected override void Shoot()
     {
         if (this._ammo > 0 && _ready)
         {

--- a/Assets/Scripts/Items/Crossbow.cs
+++ b/Assets/Scripts/Items/Crossbow.cs
@@ -21,7 +21,7 @@ public class Crossbow : Firearm
         this.bulletSpawner = ScriptableObject.CreateInstance<BulletSpawner>();
         this.bulletSpawner.Initialize(this);
     }
-    protected override void Shoot()
+    public override void Use()
     {
         if (this._ammo > 0 && _ready)
         {

--- a/Assets/Scripts/Items/ItemInterfaces.cs
+++ b/Assets/Scripts/Items/ItemInterfaces.cs
@@ -1,11 +1,12 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using UnityEngine;
 using static UnityEditor.Experimental.GraphView.GraphView;
 
 public interface IItem : IComponent
 {
-    void Use();
+    void Use(ICharacter c, int flag=0);
     void Destroy();
 }
 
@@ -22,5 +23,4 @@ public interface IFirearm : IWeapon
     float BulletSpread { get; }
     int Ammo { get; }
     int Capacity { get; }
-    int Reload(int ammo);
 }

--- a/Assets/Scripts/Items/ItemInterfaces.cs
+++ b/Assets/Scripts/Items/ItemInterfaces.cs
@@ -4,9 +4,18 @@ using System.ComponentModel;
 using UnityEngine;
 using static UnityEditor.Experimental.GraphView.GraphView;
 
+// This enum will allow us to cast up to a differennt interface
+public enum ItemType
+{
+    ITEM,
+    WEAPON,
+    FIREARM,
+    CONSUMABLE
+}
 public interface IItem : IComponent
 {
-    void Use(ICharacter c, int flag=0);
+    ItemType Type { get; }
+    void Use();
     void Destroy();
 }
 
@@ -23,4 +32,5 @@ public interface IFirearm : IWeapon
     float BulletSpread { get; }
     int Ammo { get; }
     int Capacity { get; }
+    public int Reload(int ammo);
 }

--- a/Assets/Scripts/Items/ItemInterfaces.cs
+++ b/Assets/Scripts/Items/ItemInterfaces.cs
@@ -3,20 +3,26 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
 using static UnityEditor.Experimental.GraphView.GraphView;
+using static UnityEditor.Progress;
 
-// This enum will allow us to cast up to a differennt interface
+// This enum will allow us to cast up to a different interface of importance
 public enum ItemType
 {
-    ITEM,
-    WEAPON,
     FIREARM,
-    CONSUMABLE
+    DROP
 }
 public interface IItem : IComponent
 {
     ItemType Type { get; }
-    void Use();
     void Destroy();
+}
+public interface IDropItem : IItem
+{
+    public void OnTriggerEnter2D(Collider2D collision);
+}
+public interface IHoldableItem : IItem
+{
+    void Use();
 }
 
 public interface IWeapon : IItem

--- a/Assets/Scripts/Items/Pistol.cs
+++ b/Assets/Scripts/Items/Pistol.cs
@@ -21,7 +21,7 @@ public class Pistol : Firearm
         this.bulletSpawner = ScriptableObject.CreateInstance<BulletSpawner>();
         this.bulletSpawner.Initialize(this);
     }
-    protected override void Shoot()
+    public override void Use()
     {
         if (this._ammo > 0 && _ready)
         {

--- a/Assets/Scripts/Items/Pistol.cs
+++ b/Assets/Scripts/Items/Pistol.cs
@@ -21,7 +21,7 @@ public class Pistol : Firearm
         this.bulletSpawner = ScriptableObject.CreateInstance<BulletSpawner>();
         this.bulletSpawner.Initialize(this);
     }
-    public override void Use()
+    protected override void Shoot()
     {
         if (this._ammo > 0 && _ready)
         {

--- a/Assets/Scripts/Items/SniperRifle.cs
+++ b/Assets/Scripts/Items/SniperRifle.cs
@@ -21,7 +21,7 @@ public class SniperRifle : Firearm
         this.bulletSpawner = ScriptableObject.CreateInstance<BulletSpawner>();
         this.bulletSpawner.Initialize(this);
     }
-    protected override void Shoot()
+    public override void Use()
     {
         if (this._ammo > 0 && _ready)
         {

--- a/Assets/Scripts/Items/SniperRifle.cs
+++ b/Assets/Scripts/Items/SniperRifle.cs
@@ -15,13 +15,13 @@ public class SniperRifle : Firearm
         this._range = 200f;
         this._bulletSpeed = 100f;
         this._bulletSpread = 1f;
-        this._capacity = 6;
+        this._capacity = 4;
         this._ammo = this._capacity;
         this._ready = true;
         this.bulletSpawner = ScriptableObject.CreateInstance<BulletSpawner>();
         this.bulletSpawner.Initialize(this);
     }
-    public override void Use()
+    protected override void Shoot()
     {
         if (this._ammo > 0 && _ready)
         {

--- a/Assets/Scripts/Items/Weapon.cs
+++ b/Assets/Scripts/Items/Weapon.cs
@@ -4,21 +4,23 @@ using UnityEngine;
 using static Unity.IO.LowLevel.Unsafe.AsyncReadManagerMetrics;
 using static UnityEditor.Experimental.GraphView.GraphView;
 
-
 public abstract class Item : MonoBehaviour, IItem
 {
     public Component component { get { return this; } }
 
     public abstract ItemType Type { get; }
 
-    public abstract void Use();
 
     public void Destroy()
     {
         Destroy(gameObject);
     }
 }
-public abstract class Weapon : Item, IWeapon
+public abstract class IHoldabletem : Item, IHoldableItem
+{
+    public abstract void Use();
+}
+public abstract class Weapon : IHoldabletem, IWeapon
 {
     protected float _damage;
     protected float _delay;

--- a/Assets/Scripts/Items/Weapon.cs
+++ b/Assets/Scripts/Items/Weapon.cs
@@ -9,7 +9,9 @@ public abstract class Item : MonoBehaviour, IItem
 {
     public Component component { get { return this; } }
 
-    public abstract void Use(ICharacter c, int flag= 0);
+    public abstract ItemType Type { get; }
+
+    public abstract void Use();
 
     public void Destroy()
     {
@@ -71,25 +73,11 @@ public abstract class Firearm : Weapon, IFirearm
         yield return new WaitForSeconds(_delay);
         _ready = true;
     }
-    public override void Use(ICharacter c, int flag = 0)
-    {
-        if(flag == 0)
-        {
-            // Shoot the gun
-            this.Shoot();
-        } else if (flag == 1)
-        {
-            // Reload the gun
-            int max_ammo = this._capacity - this._ammo;
-            int actual_ammo = Mathf.Min(c.Ammo, max_ammo);
-            this.Reload(actual_ammo);
-            c.UseAmmo(actual_ammo);
-        }
+    public override ItemType Type {
+        get { return ItemType.FIREARM; }
     }
-    // All guns shoot differently
-    protected abstract void Shoot();
     // All guns reload the same way
-    protected int Reload(int ammo)
+    public int Reload(int ammo)
     {
         if(this.Ammo + ammo <= this.Capacity)
         {

--- a/Assets/Scripts/Items/Weapon.cs
+++ b/Assets/Scripts/Items/Weapon.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static Unity.IO.LowLevel.Unsafe.AsyncReadManagerMetrics;
 using static UnityEditor.Experimental.GraphView.GraphView;
 
 
@@ -8,7 +9,7 @@ public abstract class Item : MonoBehaviour, IItem
 {
     public Component component { get { return this; } }
 
-    public abstract void Use();
+    public abstract void Use(ICharacter c, int flag= 0);
 
     public void Destroy()
     {
@@ -70,7 +71,25 @@ public abstract class Firearm : Weapon, IFirearm
         yield return new WaitForSeconds(_delay);
         _ready = true;
     }
-    public int Reload(int ammo)
+    public override void Use(ICharacter c, int flag = 0)
+    {
+        if(flag == 0)
+        {
+            // Shoot the gun
+            this.Shoot();
+        } else if (flag == 1)
+        {
+            // Reload the gun
+            int max_ammo = this._capacity - this._ammo;
+            int actual_ammo = Mathf.Min(c.Ammo, max_ammo);
+            this.Reload(actual_ammo);
+            c.UseAmmo(actual_ammo);
+        }
+    }
+    // All guns shoot differently
+    protected abstract void Shoot();
+    // All guns reload the same way
+    protected int Reload(int ammo)
     {
         if(this.Ammo + ammo <= this.Capacity)
         {

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -26,6 +26,7 @@ public class Player : ControllableCharacter
         playerControls.Player.Look.performed += Look;
         playerControls.Player.Use.performed += UseItem;
         playerControls.Player.Inventory.performed += Inventory;
+        playerControls.Player.Reload.performed += Reload;
     }
 
     private void OnDisable()
@@ -78,6 +79,14 @@ public class Player : ControllableCharacter
             {
                 character.Hotkey = key - 1;
             }
+        }
+    }
+
+    private void Reload(InputAction.CallbackContext context)
+    {
+        if (character)
+        {
+            character.UseItem(1);
         }
     }
     // Update is called once per frame

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -86,7 +86,7 @@ public class Player : ControllableCharacter
     {
         if (character)
         {
-            character.UseItem(1);
+            character.Reload();
         }
     }
     // Update is called once per frame

--- a/Assets/Scripts/PlayerActions.cs
+++ b/Assets/Scripts/PlayerActions.cs
@@ -62,6 +62,15 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Reload"",
+                    ""type"": ""Button"",
+                    ""id"": ""d1ae5310-2d49-4ac0-a679-e9b72632a182"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -392,6 +401,17 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""Inventory"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""2554c944-47ef-4682-a783-ce00939f588f"",
+                    ""path"": ""<Keyboard>/e"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Reload"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -983,6 +1003,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         m_Player_Look = m_Player.FindAction("Look", throwIfNotFound: true);
         m_Player_Use = m_Player.FindAction("Use", throwIfNotFound: true);
         m_Player_Inventory = m_Player.FindAction("Inventory", throwIfNotFound: true);
+        m_Player_Reload = m_Player.FindAction("Reload", throwIfNotFound: true);
         // UI
         m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
         m_UI_Navigate = m_UI.FindAction("Navigate", throwIfNotFound: true);
@@ -1060,6 +1081,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Look;
     private readonly InputAction m_Player_Use;
     private readonly InputAction m_Player_Inventory;
+    private readonly InputAction m_Player_Reload;
     public struct PlayerActions
     {
         private @PlayerInputActions m_Wrapper;
@@ -1068,6 +1090,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         public InputAction @Look => m_Wrapper.m_Player_Look;
         public InputAction @Use => m_Wrapper.m_Player_Use;
         public InputAction @Inventory => m_Wrapper.m_Player_Inventory;
+        public InputAction @Reload => m_Wrapper.m_Player_Reload;
         public InputActionMap Get() { return m_Wrapper.m_Player; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -1089,6 +1112,9 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
             @Inventory.started += instance.OnInventory;
             @Inventory.performed += instance.OnInventory;
             @Inventory.canceled += instance.OnInventory;
+            @Reload.started += instance.OnReload;
+            @Reload.performed += instance.OnReload;
+            @Reload.canceled += instance.OnReload;
         }
 
         private void UnregisterCallbacks(IPlayerActions instance)
@@ -1105,6 +1131,9 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
             @Inventory.started -= instance.OnInventory;
             @Inventory.performed -= instance.OnInventory;
             @Inventory.canceled -= instance.OnInventory;
+            @Reload.started -= instance.OnReload;
+            @Reload.performed -= instance.OnReload;
+            @Reload.canceled -= instance.OnReload;
         }
 
         public void RemoveCallbacks(IPlayerActions instance)
@@ -1291,6 +1320,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         void OnLook(InputAction.CallbackContext context);
         void OnUse(InputAction.CallbackContext context);
         void OnInventory(InputAction.CallbackContext context);
+        void OnReload(InputAction.CallbackContext context);
     }
     public interface IUIActions
     {

--- a/Assets/Scripts/Spawners/AmmoSpawner.cs
+++ b/Assets/Scripts/Spawners/AmmoSpawner.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AmmoSpawner : Spawner
+{
+    private int count;
+    private GameObject ammoPrefab;
+
+    public void Initialize(int count)
+    {
+        this.count = count;
+        ammoPrefab = Resources.Load<GameObject>("Prefabs/Ammo");
+    }
+    public override GameObject spawn(Vector3 location)
+    {
+        GameObject ammoObject = Instantiate(ammoPrefab, location, Quaternion.identity);
+        Ammo c = ammoObject.GetComponent<Ammo>();
+        c.Count = count;
+        return ammoObject;
+    }
+}

--- a/Assets/Scripts/Spawners/AmmoSpawner.cs.meta
+++ b/Assets/Scripts/Spawners/AmmoSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6289b7400861c49418399549e056b2ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spawners/AmmoSpawnerButton.cs
+++ b/Assets/Scripts/Spawners/AmmoSpawnerButton.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AmmoSpawnerButton : MonoBehaviour
+{
+    [SerializeField]
+    private int count;
+    private AmmoSpawner ammoSpawner;
+    // Update is called once per frame
+    void Awake()
+    {
+        ammoSpawner = ScriptableObject.CreateInstance<AmmoSpawner>();
+        ammoSpawner.Initialize(count);
+    }
+    void OnMouseDown()
+    {
+        ammoSpawner.spawn(new Vector3(5f, 0f, 0f));
+    }
+}

--- a/Assets/Scripts/Spawners/AmmoSpawnerButton.cs.meta
+++ b/Assets/Scripts/Spawners/AmmoSpawnerButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e94f5bf92b7682046bdfe929b6be89bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spawners/RangerSpawner.cs
+++ b/Assets/Scripts/Spawners/RangerSpawner.cs
@@ -21,7 +21,7 @@ public class RangerSpawner : Spawner
         // Obtain a pistol
         GameObject crossbowObject = crossbowSpawner.spawn(c.transform.position);
         // Set up the player
-        c.PickUpItem(crossbowObject.GetComponent<IItem>());
+        c.PickUpItem(crossbowObject.GetComponent<IHoldableItem>());
         return characterObject;
     }
 }

--- a/Assets/Scripts/Spawners/SniperSpawner.cs
+++ b/Assets/Scripts/Spawners/SniperSpawner.cs
@@ -21,7 +21,7 @@ public class SniperSpawner : Spawner
         // Obtain a pistol
         GameObject sniperRifleObject = sniperRifleSpawner.spawn(c.transform.position);
         // Set up the player
-        c.PickUpItem(sniperRifleObject.GetComponent<IItem>());
+        c.PickUpItem(sniperRifleObject.GetComponent<IHoldableItem>());
         return characterObject;
     }
 }

--- a/Assets/Scripts/Spawners/SoldierSpawner.cs
+++ b/Assets/Scripts/Spawners/SoldierSpawner.cs
@@ -21,7 +21,7 @@ public class SoldierSpawner : Spawner
         // Obtain a pistol
         GameObject pistolObject = pistolSpawner.spawn(c.transform.position);
         // Set up the player
-        c.PickUpItem(pistolObject.GetComponent<IItem>());
+        c.PickUpItem(pistolObject.GetComponent<IHoldableItem>());
         return characterObject;
     }
 }


### PR DESCRIPTION
This PR consists of a refactored system for the Item system. This refactoring segwayed into implementing reloading and picking up consumables from the ground, such as ammo. A rough list of edits are as follows:

- IHoldableItem and IDropItem distinction from IItem
- Reload keybinds in InputSystem
- Ammo logic and variables in Character
- DropItem abstract class to implement IDropItem
- Ammo implementation of DropItem that, when picked up by a player, will add ammo to the character
- AmmoSpawner and AmmoSpawnerButton (for testing)