### PR TITLE
28 reload causes a cooldown

### DIFF
--- a/Assets/PlayerActions.inputactions
+++ b/Assets/PlayerActions.inputactions
@@ -49,6 +49,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Drop",
+                    "type": "Button",
+                    "id": "5e276268-ee6b-4ab7-bfaa-91fb680f75b6",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -390,6 +399,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Reload",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8c49b9c7-ee8c-4287-9bfe-d7ac6199a3cf",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Drop",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Resources/Prefabs/Crossbow.prefab
+++ b/Assets/Resources/Prefabs/Crossbow.prefab
@@ -626,6 +626,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4382794139177694766}
   - component: {fileID: 8391857278192314093}
+  - component: {fileID: 6758209533149560860}
   m_Layer: 8
   m_Name: Crossbow
   m_TagString: Untagged
@@ -668,3 +669,52 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 7101615105913135718, guid: e1303cce6a30d534a95c0fbeaa1708c5, type: 3}
+--- !u!60 &6758209533149560860
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8722466834790146097}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -0.01298248, y: 0.8403784}
+      - {x: -0.571319, y: 0.0065760612}
+      - {x: -0.029538453, y: -0.80901706}
+      - {x: 0.54535383, y: -0.0018250346}
+  m_UseDelaunayMesh: 0

--- a/Assets/Resources/Prefabs/Pistol.prefab
+++ b/Assets/Resources/Prefabs/Pistol.prefab
@@ -94,6 +94,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4382794139177694766}
   - component: {fileID: -165273938450606623}
+  - component: {fileID: 9126221944883170665}
   m_Layer: 8
   m_Name: Pistol
   m_TagString: Untagged
@@ -131,6 +132,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 7101615105913135718, guid: e1303cce6a30d534a95c0fbeaa1708c5, type: 3}
+--- !u!61 &9126221944883170665
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8722466834790146097}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.19331229, y: -0.000000033527613}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2.3824756, y: 0.20244282}
+  m_EdgeRadius: 0
 --- !u!1 &8748987007241295549
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/SniperRifle.prefab
+++ b/Assets/Resources/Prefabs/SniperRifle.prefab
@@ -346,6 +346,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4382794139177694766}
   - component: {fileID: 7661344481854533615}
+  - component: {fileID: 2076728370929157838}
   m_Layer: 8
   m_Name: SniperRifle
   m_TagString: Untagged
@@ -385,3 +386,48 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 7101615105913135718, guid: e1303cce6a30d534a95c0fbeaa1708c5, type: 3}
+--- !u!61 &2076728370929157838
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8722466834790146097}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.272182, y: -0.019570328}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2.653254, y: 0.36070442}
+  m_EdgeRadius: 0

--- a/Assets/Scripts/Characters/Character.cs
+++ b/Assets/Scripts/Characters/Character.cs
@@ -41,7 +41,7 @@ public interface IInventory
     int InventorySize { get; }
     int Hotkey { get; set; }
     void UseItem();
-    void PickUpItem(IHoldableItem item);
+    void PickUpItem(IInventoryItem item);
     void DropItem();
 }
 
@@ -58,7 +58,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     protected float _defense;
     protected int _hotkey;
     protected int _ammo;
-    protected IHoldableItem[] _inventory;
+    protected IInventoryItem[] _inventory;
 
     // Implementations of interface functions and variables
     public Component component { get { return this; } }
@@ -156,7 +156,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
             }
         }
     }
-    public void PickUpItem(IHoldableItem item)
+    public void PickUpItem(IInventoryItem item)
     {
         for(int i = 0; i < _inventory.Length; i++)
         {
@@ -172,7 +172,7 @@ public abstract class Character : MonoBehaviour, ICharacter, IInventory
     {
         if (_inventory[_hotkey] != null)
         {
-            _inventory[_hotkey].Destroy();
+            _inventory[_hotkey].OnDrop();
             _inventory[_hotkey] = null;
         }
     }

--- a/Assets/Scripts/Characters/Ranger.cs
+++ b/Assets/Scripts/Characters/Ranger.cs
@@ -20,6 +20,6 @@ public class Ranger : Character
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
         this._ammo = 32;
-        this._inventory = new IHoldableItem[5];
+        this._inventory = new IInventoryItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Sniper.cs
+++ b/Assets/Scripts/Characters/Sniper.cs
@@ -20,6 +20,6 @@ public class Sniper : Character
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
         this._ammo = 32;
-        this._inventory = new IHoldableItem[5];
+        this._inventory = new IInventoryItem[5];
     }
 }

--- a/Assets/Scripts/Characters/Soldier.cs
+++ b/Assets/Scripts/Characters/Soldier.cs
@@ -20,6 +20,6 @@ public class Soldier : Character
         this._maxHealth = defaultHealth;
         this._defense = defaultDefense;
         this._ammo = 64;
-        this._inventory = new IHoldableItem[5];
+        this._inventory = new IInventoryItem[5];
     }
 }

--- a/Assets/Scripts/Items/Ammo.cs
+++ b/Assets/Scripts/Items/Ammo.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using static UnityEditor.Experimental.GraphView.GraphView;
 
-public class Ammo : DropItem
+public class Ammo : FloorItem
 {
     private int _count;
 

--- a/Assets/Scripts/Items/Consumable.cs
+++ b/Assets/Scripts/Items/Consumable.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class DropItem : Item, IDropItem
+public abstract class FloorItem : Item, IFloorItem
 {
     public override ItemType Type
     {

--- a/Assets/Scripts/Items/Crossbow.cs
+++ b/Assets/Scripts/Items/Crossbow.cs
@@ -10,11 +10,12 @@ public class Crossbow : Firearm
     private void Awake()
     {
         // TEMP HIGH DAMAGE: DEATH IN 5 SHOTS
-        this._damage = 100f;
-        this._delay = 1.0f;
+        this._damage = 60f;
+        this._delay = 0.5f;
+        this._reloadTime = 3f;
         this._range = 150f;
         this._bulletSpeed = 40f;
-        this._bulletSpread = 5f;
+        this._bulletSpread = 2.5f;
         this._capacity = 8;
         this._ammo = this._capacity;
         this._ready = true;
@@ -26,8 +27,8 @@ public class Crossbow : Firearm
         if (this._ammo > 0 && _ready)
         {
             bulletSpawner.spawn(transform.position);
-            StartCoroutine(Cooldown());
             this._ammo--;
+            StartCoroutine(Cooldown(_delay));
         }
     }
 }

--- a/Assets/Scripts/Items/ItemInterfaces.cs
+++ b/Assets/Scripts/Items/ItemInterfaces.cs
@@ -16,16 +16,22 @@ public interface IItem : IComponent
     ItemType Type { get; }
     void Destroy();
 }
-public interface IDropItem : IItem
+public interface IFloorItem : IItem
 {
     public void OnTriggerEnter2D(Collider2D collision);
 }
-public interface IHoldableItem : IItem
+
+public interface IDropItem : IItem
+{
+    void OnDrop();
+}
+
+public interface IInventoryItem : IFloorItem, IDropItem
 {
     void Use();
 }
 
-public interface IWeapon : IItem
+public interface IWeapon : IInventoryItem
 {
     float Damage { get; }
     float Delay { get; }

--- a/Assets/Scripts/Items/ItemInterfaces.cs
+++ b/Assets/Scripts/Items/ItemInterfaces.cs
@@ -38,5 +38,6 @@ public interface IFirearm : IWeapon
     float BulletSpread { get; }
     int Ammo { get; }
     int Capacity { get; }
+    float ReloadTime { get; }
     public int Reload(int ammo);
 }

--- a/Assets/Scripts/Items/Pistol.cs
+++ b/Assets/Scripts/Items/Pistol.cs
@@ -10,8 +10,9 @@ public class Pistol : Firearm
     private void Awake()
     {
         // TEMP HIGH DAMAGE: DEATH IN 5 SHOTS
-        this._damage = 60f;
+        this._damage = 30f;
         this._delay = 0.2f;
+        this._reloadTime = 3f;
         this._range = 100f;
         this._bulletSpeed = 50f;
         this._bulletSpread = 5f;
@@ -26,8 +27,8 @@ public class Pistol : Firearm
         if (this._ammo > 0 && _ready)
         {
             bulletSpawner.spawn(transform.position);
-            StartCoroutine(Cooldown());
             this._ammo--;
+            StartCoroutine(Cooldown(_delay));
         }
     }
 }

--- a/Assets/Scripts/Items/SniperRifle.cs
+++ b/Assets/Scripts/Items/SniperRifle.cs
@@ -10,11 +10,12 @@ public class SniperRifle : Firearm
     private void Awake()
     {
         // two(?) shot
-        this._damage = 200f;
+        this._damage = 150f;
         this._delay = 1.5f;
+        this._reloadTime = 1f;
         this._range = 200f;
         this._bulletSpeed = 100f;
-        this._bulletSpread = 1f;
+        this._bulletSpread = 0.5f;
         this._capacity = 4;
         this._ammo = this._capacity;
         this._ready = true;
@@ -26,8 +27,8 @@ public class SniperRifle : Firearm
         if (this._ammo > 0 && _ready)
         {
             bulletSpawner.spawn(transform.position);
-            StartCoroutine(Cooldown());
             this._ammo--;
+            StartCoroutine(Cooldown(_delay));
         }
     }
 }

--- a/Assets/Scripts/Items/Weapon.cs
+++ b/Assets/Scripts/Items/Weapon.cs
@@ -51,6 +51,7 @@ public abstract class Firearm : Weapon, IFirearm
     protected int _capacity;
     protected int _ammo;
     protected bool _ready;
+    protected float _reloadTime;
     protected BulletSpawner bulletSpawner;
     public int Ammo
     {
@@ -69,10 +70,14 @@ public abstract class Firearm : Weapon, IFirearm
     {
         get { return _bulletSpread; }
     }
-    protected IEnumerator Cooldown()
+    public float ReloadTime
+    {
+        get { return _reloadTime; }
+    }
+    protected IEnumerator Cooldown(float time)
     {
         _ready = false;
-        yield return new WaitForSeconds(_delay);
+        yield return new WaitForSeconds(time);
         _ready = true;
     }
     public override ItemType Type {
@@ -81,10 +86,16 @@ public abstract class Firearm : Weapon, IFirearm
     // All guns reload the same way
     public int Reload(int ammo)
     {
-        if(this.Ammo + ammo <= this.Capacity)
+        // If we aren't ready return same amount
+        if(!_ready)
+        {
+            return ammo;
+        }
+        StartCoroutine(Cooldown(_reloadTime));
+        if (this.Ammo + ammo <= this.Capacity)
         {
             this._ammo += ammo;
-            // No ammo remaining
+            // No ammo remaining 
             return 0;
         } else
         {

--- a/Assets/Scripts/Items/Weapon.cs
+++ b/Assets/Scripts/Items/Weapon.cs
@@ -10,17 +10,41 @@ public abstract class Item : MonoBehaviour, IItem
 
     public abstract ItemType Type { get; }
 
-
     public void Destroy()
     {
         Destroy(gameObject);
     }
 }
-public abstract class IHoldabletem : Item, IHoldableItem
+public abstract class InventoryItem : Item, IInventoryItem
 {
     public abstract void Use();
+
+    private IEnumerator OnDropActivate()
+    {
+        yield return new WaitForSeconds(2f);
+        this.gameObject.GetComponent<Collider2D>().enabled = true;
+    }
+    public void OnDrop()
+    {
+        // Cooldown on grabbing again, needs to be a separate function call
+        StartCoroutine(OnDropActivate());
+    }
+    public void OnTriggerEnter2D(Collider2D collision)
+    {
+        Character c = collision.gameObject.GetComponent<Character>();
+        // Must be picked up by a character
+        if (c)
+        {
+            // Must be a player
+            if (c.gameObject.layer == Layers.PLAYER)
+            {
+                this.gameObject.GetComponent<Collider2D>().enabled = false;
+                c.PickUpItem(this);
+            }
+        }
+    }
 }
-public abstract class Weapon : IHoldabletem, IWeapon
+public abstract class Weapon : InventoryItem, IWeapon
 {
     protected float _damage;
     protected float _delay;
@@ -74,6 +98,7 @@ public abstract class Firearm : Weapon, IFirearm
     {
         get { return _reloadTime; }
     }
+    // REDEFINE
     protected IEnumerator Cooldown(float time)
     {
         _ready = false;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -27,6 +27,7 @@ public class Player : ControllableCharacter
         playerControls.Player.Use.performed += UseItem;
         playerControls.Player.Inventory.performed += Inventory;
         playerControls.Player.Reload.performed += Reload;
+        playerControls.Player.Drop.performed += Drop;
     }
 
     private void OnDisable()
@@ -87,6 +88,14 @@ public class Player : ControllableCharacter
         if (character)
         {
             character.Reload();
+        }
+    }
+
+    private void Drop(InputAction.CallbackContext context)
+    {
+        if (character)
+        {
+            character.DropItem();
         }
     }
     // Update is called once per frame

--- a/Assets/Scripts/PlayerActions.cs
+++ b/Assets/Scripts/PlayerActions.cs
@@ -71,6 +71,15 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Drop"",
+                    ""type"": ""Button"",
+                    ""id"": ""5e276268-ee6b-4ab7-bfaa-91fb680f75b6"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -412,6 +421,17 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""Reload"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""8c49b9c7-ee8c-4287-9bfe-d7ac6199a3cf"",
+                    ""path"": ""<Keyboard>/q"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Drop"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -1004,6 +1024,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         m_Player_Use = m_Player.FindAction("Use", throwIfNotFound: true);
         m_Player_Inventory = m_Player.FindAction("Inventory", throwIfNotFound: true);
         m_Player_Reload = m_Player.FindAction("Reload", throwIfNotFound: true);
+        m_Player_Drop = m_Player.FindAction("Drop", throwIfNotFound: true);
         // UI
         m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
         m_UI_Navigate = m_UI.FindAction("Navigate", throwIfNotFound: true);
@@ -1082,6 +1103,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Use;
     private readonly InputAction m_Player_Inventory;
     private readonly InputAction m_Player_Reload;
+    private readonly InputAction m_Player_Drop;
     public struct PlayerActions
     {
         private @PlayerInputActions m_Wrapper;
@@ -1091,6 +1113,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         public InputAction @Use => m_Wrapper.m_Player_Use;
         public InputAction @Inventory => m_Wrapper.m_Player_Inventory;
         public InputAction @Reload => m_Wrapper.m_Player_Reload;
+        public InputAction @Drop => m_Wrapper.m_Player_Drop;
         public InputActionMap Get() { return m_Wrapper.m_Player; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -1115,6 +1138,9 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
             @Reload.started += instance.OnReload;
             @Reload.performed += instance.OnReload;
             @Reload.canceled += instance.OnReload;
+            @Drop.started += instance.OnDrop;
+            @Drop.performed += instance.OnDrop;
+            @Drop.canceled += instance.OnDrop;
         }
 
         private void UnregisterCallbacks(IPlayerActions instance)
@@ -1134,6 +1160,9 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
             @Reload.started -= instance.OnReload;
             @Reload.performed -= instance.OnReload;
             @Reload.canceled -= instance.OnReload;
+            @Drop.started -= instance.OnDrop;
+            @Drop.performed -= instance.OnDrop;
+            @Drop.canceled -= instance.OnDrop;
         }
 
         public void RemoveCallbacks(IPlayerActions instance)
@@ -1321,6 +1350,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         void OnUse(InputAction.CallbackContext context);
         void OnInventory(InputAction.CallbackContext context);
         void OnReload(InputAction.CallbackContext context);
+        void OnDrop(InputAction.CallbackContext context);
     }
     public interface IUIActions
     {

--- a/Assets/Scripts/Spawners/RangerSpawner.cs
+++ b/Assets/Scripts/Spawners/RangerSpawner.cs
@@ -21,7 +21,7 @@ public class RangerSpawner : Spawner
         // Obtain a pistol
         GameObject crossbowObject = crossbowSpawner.spawn(c.transform.position);
         // Set up the player
-        c.PickUpItem(crossbowObject.GetComponent<IHoldableItem>());
+        c.PickUpItem(crossbowObject.GetComponent<IInventoryItem>());
         return characterObject;
     }
 }

--- a/Assets/Scripts/Spawners/SniperSpawner.cs
+++ b/Assets/Scripts/Spawners/SniperSpawner.cs
@@ -21,7 +21,7 @@ public class SniperSpawner : Spawner
         // Obtain a pistol
         GameObject sniperRifleObject = sniperRifleSpawner.spawn(c.transform.position);
         // Set up the player
-        c.PickUpItem(sniperRifleObject.GetComponent<IHoldableItem>());
+        c.PickUpItem(sniperRifleObject.GetComponent<IInventoryItem>());
         return characterObject;
     }
 }

--- a/Assets/Scripts/Spawners/SoldierSpawner.cs
+++ b/Assets/Scripts/Spawners/SoldierSpawner.cs
@@ -21,7 +21,7 @@ public class SoldierSpawner : Spawner
         // Obtain a pistol
         GameObject pistolObject = pistolSpawner.spawn(c.transform.position);
         // Set up the player
-        c.PickUpItem(pistolObject.GetComponent<IHoldableItem>());
+        c.PickUpItem(pistolObject.GetComponent<IInventoryItem>());
         return characterObject;
     }
 }


### PR DESCRIPTION
This PR contains droppable items and a cooldown feature for reloading. Here are the primary changes:

- Refactors to Item interface structure, most notable IFloorItem and IDropItem define behaviors of items and IInventoryItem takes them both (inventory items can be dropped and picked up)
- Dropping an item uses Q on the keyboard, and the item is temporarily disabled for 2s until it can be picked up again
- Reload Time is a parameter of weapons and disables the item from being used for that time

Some other bugfixes were also done and small changes...